### PR TITLE
refactor(validator): 优化插件处理逻辑并更新依赖

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/linabellbiu/goctl-validate
 go 1.23.7
 
 require (
+	github.com/go-playground/locales v0.14.1
+	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.25.0
 	github.com/spf13/cobra v1.9.1
 	github.com/zeromicro/go-zero/tools/goctl v1.8.1
-	github.com/go-playground/locales v0.14.1
-	github.com/go-playground/universal-translator v0.18.1
 )
 
 require (
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	github.com/zeromicro/antlr v0.0.1 // indirect
-	github.com/zeromicro/go-zero v1.8.1 // indirect
+	github.com/zeromicro/go-zero v1.8.5 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/zeromicro/antlr v0.0.1 h1:CQpIn/dc0pUjgGQ81y98s/NGOm2Hfru2NNio2I9mQgk
 github.com/zeromicro/antlr v0.0.1/go.mod h1:nfpjEwFR6Q4xGDJMcZnCL9tEfQRgszMwu3rDz2Z+p5M=
 github.com/zeromicro/go-zero v1.8.1 h1:iUYQEMQzS9Pb8ebzJtV3FGtv/YTjZxAh/NvLW/316wo=
 github.com/zeromicro/go-zero v1.8.1/go.mod h1:gc54Ad4qt7OJ0PbKajnYsSKsZBYN4JLRIXKlqDX2A2I=
+github.com/zeromicro/go-zero v1.8.5 h1:YkdQhYllE+BPOrxcni0oCewebs7qHfXvjN9glnpcmJQ=
+github.com/zeromicro/go-zero v1.8.5/go.mod h1:P0DKW1vJx+2J3TReptbeg0H9tRSvehymr0HX4SCfZ6g=
 github.com/zeromicro/go-zero/tools/goctl v1.8.1 h1:PgzmR4VMgaWCSKbqgcmxj9iSq8qK9Hk4icIl9hm0lYc=
 github.com/zeromicro/go-zero/tools/goctl v1.8.1/go.mod h1:ioCZo6Xeyi7mRwWnJhkoUzzJ/3I7AETrUB23+TKuQ+Q=
 golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=

--- a/internal/validator/plugin.go
+++ b/internal/validator/plugin.go
@@ -2,24 +2,49 @@ package validator
 
 import (
 	"fmt"
-	"github.com/linabellbiu/goctl-validate/internal/processor"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/linabellbiu/goctl-validate/internal/processor"
 
 	"github.com/zeromicro/go-zero/tools/goctl/plugin"
 )
 
 // ProcessPlugin 处理插件逻辑
 func ProcessPlugin(p *plugin.Plugin, options processor.Options) error {
-	// 查找并处理types.go文件
-	err := filepath.Walk(p.Dir, func(path string, info os.FileInfo, err error) error {
+	// 构建types目录路径
+	typesDir := filepath.Join(p.Dir, "internal", "types")
+
+	// 检查types目录是否存在
+	if _, err := os.Stat(typesDir); os.IsNotExist(err) {
+		if options.DebugMode {
+			fmt.Printf("types目录不存在: %s\n", typesDir)
+		}
+		return nil
+	}
+
+	// 遍历types目录下的所有go文件
+	err := filepath.Walk(typesDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && strings.HasSuffix(info.Name(), "types.go") {
+		// 打印当前处理的文件路径
+		fmt.Println("当前处理文件:", path)
+
+		// 只处理go文件，并过滤掉validation.go和translator.go
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".go") {
+			// 过滤掉validation.go和translator.go文件
+			fileName := info.Name()
+			if fileName == "validation.go" || fileName == "translator.go" {
+				if options.DebugMode {
+					fmt.Printf("跳过文件: %s\n", path)
+				}
+				return nil
+			}
+
 			if options.DebugMode {
-				fmt.Printf("处理types.go文件: %s\n", path)
+				fmt.Printf("处理go文件: %s\n", path)
 			}
 			if err := processor.ProcessTypesFile(path, options); err != nil {
 				return err

--- a/main.go
+++ b/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/linabellbiu/goctl-validate/internal/processor"
 	"github.com/linabellbiu/goctl-validate/internal/validator"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/zeromicro/go-zero/tools/goctl/plugin"
@@ -12,7 +13,7 @@ import (
 
 var (
 	// 版本信息
-	version = "1.1.0"
+	version = "1.1.1"
 	// 是否添加自定义验证方法
 	enableCustomValidation bool
 	// 是否启用调试模式


### PR DESCRIPTION
重构插件获取文件的逻辑,用来适配go-zero1.8.3版本以上使用goctl api go --api $api --dir $output --type-group 分组模式生成的结构体 更新go-zero依赖至v1.8.5版本